### PR TITLE
Update index.less

### DIFF
--- a/index.less
+++ b/index.less
@@ -157,6 +157,12 @@ atom-text-editor, :host {
   color: @yellow;
 }
 
+.syntax--string {
+  &.syntax--unquoted {
+    color: @blue;
+  }
+}
+
 .support {
   &.constant,
   &.function {


### PR DESCRIPTION
This fix is to match the monokai theme from Brackets. It makes more sense to use the blue color for unquoted strings.